### PR TITLE
fix(getters): gracefully handle errors when fetching data from GitHub

### DIFF
--- a/src/getters/getBumpPR.ts
+++ b/src/getters/getBumpPR.ts
@@ -4,13 +4,18 @@ export async function getBumpPR(
   repo: string,
   owner: string = "patternfly-extension-testing"
 ): Promise<number> {
-  const res = await octokit.request("GET /repos/{owner}/{repo}/pulls", {
-    repo,
-    owner,
-  });
+  const res = await octokit
+    .request("GET /repos/{owner}/{repo}/pulls", {
+      repo,
+      owner,
+    })
+    .catch((err) => {
+      console.error(err);
+      return { status: err.status, data: [] };
+    });
 
   if (res.status !== 200) {
-    console.log(res)
+    console.log(res);
     return 0;
   }
 

--- a/src/getters/getRepos.ts
+++ b/src/getters/getRepos.ts
@@ -3,9 +3,14 @@ import octokit from "../octokit";
 export async function getRepos(
   owner: string = "patternfly-extension-testing"
 ): Promise<string[]> {
-  const response = await octokit.request("GET /orgs/{owner}/repos", {
-    owner,
-  });
+  const response = await octokit
+    .request("GET /orgs/{owner}/repos", {
+      owner,
+    })
+    .catch((err) => {
+      console.error(err);
+      return { status: err.status, data: []};
+    });
 
   if (response.status !== 200) {
     console.log(response);

--- a/src/getters/getStatus.ts
+++ b/src/getters/getStatus.ts
@@ -20,18 +20,12 @@ export async function getStatus(
   const workflowResults = repos.map(async (repo) => {
     const bumpNumber = await getBumpPR(repo, owner);
     const syncStatus = await getSyncStatus(repo, "main");
+    const workflowStatus = await getWorkflowResult(bumpNumber, repo, owner);
 
-    if (bumpNumber) {
-      return {
-        workflowStatus: await getWorkflowResult(bumpNumber, repo, owner),
-        syncStatus,
-      };
-    } else {
-      return {
-        workflowStatus: "Error attempting to get status",
-        syncStatus: "Error attempting to get sync status",
-      };
-    }
+    return {
+      workflowStatus,
+      syncStatus,
+    };
   });
 
   const resolvedWorkflowResults = await Promise.all(workflowResults);

--- a/src/getters/getSyncStatus.ts
+++ b/src/getters/getSyncStatus.ts
@@ -5,39 +5,46 @@ export async function getSyncStatus(
   branch: string,
   owner: string = "patternfly-extension-testing"
 ): Promise<string> {
-  const res = await octokit.request(
-    "GET /repos/{owner}/{repo}/branches/{branch}",
-    {
+  const res = await octokit
+    .request("GET /repos/{owner}/{repo}/branches/{branch}", {
       owner,
       repo,
       branch,
       headers: {
         "X-GitHub-Api-Version": "2022-11-28",
       },
-    }
-  );
+    })
+    .catch((err) => {
+      console.error(err);
+      return { status: err.status, data: { commit: { parents: [] } } };
+    });
+
   if (res.status !== 200) {
     console.log(res);
-    return `ERROR: status code: ${res.status}`;
+    return "Error attempting to get sync status";
   }
 
-  const parentCommitSHAs = res.data.commit.parents.map(commit => commit.sha)
+  const parentCommitSHAs = res.data.commit.parents.map((commit) => commit.sha);
 
-  const upstreamRes = await octokit.request(
-    "GET /repos/{owner}/{repo}/branches/{branch}",
-    {
+  const upstreamRes = await octokit
+    .request("GET /repos/{owner}/{repo}/branches/{branch}", {
       owner: "patternfly",
       repo,
       branch,
       headers: {
         "X-GitHub-Api-Version": "2022-11-28",
       },
-    }
-  );
+    })
+    .catch((err) => {
+      console.error(err);
+      return { status: err.status, data: { commit: { sha: "" } } };
+    });
 
   const upstreamHeadCommit = upstreamRes.data.commit;
 
-  const isSynced = parentCommitSHAs.some(sha => sha === upstreamHeadCommit.sha);
+  const isSynced = parentCommitSHAs.some(
+    (sha) => sha === upstreamHeadCommit.sha
+  );
 
-  return isSynced ? 'synced' : 'sync required'
+  return isSynced ? "synced" : "sync required";
 }

--- a/src/getters/getWorkflowResult.ts
+++ b/src/getters/getWorkflowResult.ts
@@ -5,17 +5,22 @@ export async function getWorkflowResult(
   repo: string,
   owner: string = "patternfly-extension-testing"
 ): Promise<string> {
-  const res = await octokit.request("GET /repos/{owner}/{repo}/actions/runs", {
-    owner,
-    repo,
-    headers: {
-      "X-GitHub-Api-Version": "2022-11-28",
-    },
-  });
+  const res = await octokit
+    .request("GET /repos/{owner}/{repo}/actions/runs", {
+      owner,
+      repo,
+      headers: {
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    })
+    .catch((err) => {
+      console.error(err);
+      return { status: err.status, data: { workflow_runs: [] } };
+    });
 
   if (res.status !== 200 || PRNumber === 0) {
     console.log(res);
-    return "";
+    return "Error attempting to get status";
   }
 
   const triggerPR = res.data.workflow_runs.find((run) => {


### PR DESCRIPTION
Closes #6

~~I'll need to resolve merge conflicts before we merge, but for testing purposes I am leaving this based on the commit before I fixed the bug that was causing Konveyor to not be fetched in #14.~~

Since #14 resolved the bug causing Konveyor to not be fetchable testing this will require pulling it down locally and checking out the first commit of this PR (before I merged main and the fix from #14 into this branch).

Once you've done that you should see all of the repos other than tackle2-ui loading in properly. Going one more commit back should cause uncaught errors to prevent any repos from loading.